### PR TITLE
pin backstage and plugin versions

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -11,6 +11,12 @@
 
 FROM --platform=linux/amd64 node:18-bullseye-slim
 
+# Install required pre-reqs for node_module dependencies
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update && \
+  apt-get install -y --no-install-recommends python3 build-essential && \
+  yarn config set python /usr/bin/python3
+
 # From here on we use the least-privileged `node` user to run the backend.
 USER node
 

--- a/scripts/backstage-install.sh
+++ b/scripts/backstage-install.sh
@@ -2,7 +2,7 @@
 
 # install base backstage app
 echo "Installing the latest Backstage app"
-BACKSTAGE_APP_NAME=backstage npx -y -q @backstage/create-app@latest --path ./backstage
+BACKSTAGE_APP_NAME=backstage npx -y -q @backstage/create-app@0.5.1 --path ./backstage
 
 # Copy the backstage-plugins into the backstage/plugins directory
 echo "Copying AWS Apps plugins"
@@ -15,22 +15,22 @@ cp ../config/app-config.aws-production.yaml .
 # Install backend dependencies
 echo "Installing backend dependencies"
 yarn --cwd packages/backend add \
-    "@roadiehq/catalog-backend-module-okta" \
-    "@immobiliarelabs/backstage-plugin-gitlab-backend" \
-    "@aws/plugin-aws-apps-backend-for-backstage" \
-    "@aws/plugin-scaffolder-backend-aws-apps-for-backstage"
+    "@roadiehq/catalog-backend-module-okta@^0.8.2" \
+    "@immobiliarelabs/backstage-plugin-gitlab-backend@^5.0.0" \
+    "@aws/plugin-aws-apps-backend-for-backstage@^0.1.2" \
+    "@aws/plugin-scaffolder-backend-aws-apps-for-backstage@^0.1.2"
 
 # Install frontend dependencies
 echo "Installing frontend dependencies"
 yarn --cwd packages/app add \
-    "@immobiliarelabs/backstage-plugin-gitlab" \
-    "@aws/plugin-aws-apps-for-backstage" \
-    "@backstage/plugin-home" \
-    "@aws/plugin-aws-apps-demo-for-backstage"
+    "@immobiliarelabs/backstage-plugin-gitlab@^5.0.0" \
+    "@aws/plugin-aws-apps-for-backstage@^0.1.2" \
+    "@backstage/plugin-home@^0.5.2" \
+    "@aws/plugin-aws-apps-demo-for-backstage@^0.1.2"
 
 # Copy/overwrite modified backstage files.
-# Note that these modifications were based on modifying Backstage 1.13 files.  
+# Note that these modifications were based on modifying Backstage 1.14 files.
 # Later versions of Backstage may modify the base versions of these files and the overwrite action may wipe out intended Backstage changes.
-# A preferred approach is to be intentional in the customization of Backstage and follow the instructions in the 
+# A preferred approach is to be intentional in the customization of Backstage and follow the instructions in the
 # plugins' README files to manually modify the Backstage source files
 \cp -R ../backstage-mods/* .


### PR DESCRIPTION
Addresses #15

*Description of changes:*
Pins the version of Backstage to 1.14.x and compatible versions of dependent plugins

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
