### PR TITLE
update install script and docs for Backstage 1.15 support

### DIFF
--- a/backstage-mods/packages/backend/src/index.ts
+++ b/backstage-mods/packages/backend/src/index.ts
@@ -15,7 +15,7 @@ import {
   notFoundHandler,
   CacheManager,
   DatabaseManager,
-  SingleHostDiscovery,
+  HostDiscovery,
   UrlReaders,
   ServerTokenManager,
 } from '@backstage/backend-common';
@@ -37,7 +37,7 @@ import awsApps from './plugins/awsApps';
 function makeCreateEnv(config: Config) {
   const root = getRootLogger();
   const reader = UrlReaders.default({ logger: root, config });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const cacheManager = CacheManager.fromConfig(config);
   const databaseManager = DatabaseManager.fromConfig(config, { logger: root });
   const tokenManager = ServerTokenManager.noop();

--- a/backstage-plugins/plugins/aws-apps-backend/README.md
+++ b/backstage-plugins/plugins/aws-apps-backend/README.md
@@ -15,7 +15,7 @@ This is the backend part of the AWS Apps plugin.  It has four primary responsibi
 
 ```sh
 # From your Backstage root directory
-yarn add --cwd packages/backend @aws/plugin-aws-apps-backend-for-backstage@0.1.0
+yarn add --cwd packages/backend @aws/plugin-aws-apps-backend-for-backstage@^0.1.0
 ```
 
 ## Configuration

--- a/backstage-plugins/plugins/aws-apps-demo/README.md
+++ b/backstage-plugins/plugins/aws-apps-demo/README.md
@@ -14,7 +14,7 @@ It provides a basic Home page with an ability to add customer-specific logo imag
 
 ```bash
 # From your Backstage root directory
-yarn add --cwd packages/app @aws/plugin-aws-apps-demo-for-backstage@0.1.0
+yarn add --cwd packages/app @aws/plugin-aws-apps-demo-for-backstage@^0.1.0
 ```
 
 ## Setup

--- a/backstage-plugins/plugins/aws-apps/README.md
+++ b/backstage-plugins/plugins/aws-apps/README.md
@@ -23,7 +23,7 @@ Install the AWS Apps frontend plugin into your Backstage application:
 
 ```sh
 # From your Backstage root directory
-yarn add --cwd packages/app @aws/plugin-aws-apps-for-backstage@0.1.0
+yarn add --cwd packages/app @aws/plugin-aws-apps-for-backstage@^0.1.0
 ```
 
 ## Configuration

--- a/backstage-plugins/plugins/scaffolder-backend-module-aws-apps/README.md
+++ b/backstage-plugins/plugins/scaffolder-backend-module-aws-apps/README.md
@@ -13,7 +13,7 @@ This plugin provides scaffolder actions to create AWS resources and utility acti
 
 ```sh
 # From your Backstage root directory
-yarn add --cwd packages/backend @aws/plugin-scaffolder-backend-aws-apps-for-backstage@0.1.0
+yarn add --cwd packages/backend @aws/plugin-scaffolder-backend-aws-apps-for-backstage@^0.1.0
 ```
 
 ## Configuration

--- a/scripts/backstage-install.sh
+++ b/scripts/backstage-install.sh
@@ -2,7 +2,7 @@
 
 # install base backstage app
 echo "Installing the latest Backstage app"
-BACKSTAGE_APP_NAME=backstage npx -y -q @backstage/create-app@0.5.1 --path ./backstage
+BACKSTAGE_APP_NAME=backstage npx -y -q @backstage/create-app@0.5.2 --path ./backstage
 
 # Copy the backstage-plugins into the backstage/plugins directory
 echo "Copying AWS Apps plugins"
@@ -15,15 +15,15 @@ cp ../config/app-config.aws-production.yaml .
 # Install backend dependencies
 echo "Installing backend dependencies"
 yarn --cwd packages/backend add \
-    "@roadiehq/catalog-backend-module-okta@^0.8.2" \
-    "@immobiliarelabs/backstage-plugin-gitlab-backend@^5.0.0" \
+    "@roadiehq/catalog-backend-module-okta@^0.8.4" \
+    "@immobiliarelabs/backstage-plugin-gitlab-backend@^6.0.0" \
     "@aws/plugin-aws-apps-backend-for-backstage@^0.1.2" \
     "@aws/plugin-scaffolder-backend-aws-apps-for-backstage@^0.1.2"
 
 # Install frontend dependencies
 echo "Installing frontend dependencies"
 yarn --cwd packages/app add \
-    "@immobiliarelabs/backstage-plugin-gitlab@^5.0.0" \
+    "@immobiliarelabs/backstage-plugin-gitlab@^6.0.0" \
     "@aws/plugin-aws-apps-for-backstage@^0.1.2" \
     "@backstage/plugin-home@^0.5.2" \
     "@aws/plugin-aws-apps-demo-for-backstage@^0.1.2"


### PR DESCRIPTION
*Issue #, if available:*  #15

*Description of changes:* Updates the install script to use Backstage 1.15.  Plugin docs also updated to use semver install notation and get the latest versions of aws-apps plugins


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
