### PR TITLE
Fix "git-defender" command existing checks

### DIFF
--- a/build-script/gitlab-tools.sh
+++ b/build-script/gitlab-tools.sh
@@ -43,9 +43,8 @@ else
     find . -type f -name "*.yaml" -exec sed -i "s/{{ *aws-account *}}/$AWS_ACCOUNT_ID/g" {} +; 
 fi
 
-IS_DEFENDER=$(type "git-defender" 2>/dev/null)
 # if the system is using git-defender and the repo is not configured, configure it
-if [[ ! -z "$IS_DEFENDER" ]] && ! grep -q "\[defender\]" .git/config ; then
+if command -v git-defender && ! grep -q "\[defender\]" .git/config ; then
   echo "Found git-defender, but repo is not configured.  Proceeding to configure repo for git-defender"
   (sleep 1; echo -e "y\n"; sleep 1; echo -e "y\n";)|git defender --setup
   echo ""


### PR DESCRIPTION
Switched from IS_DEFENDER variable to inline if using `command -v git-defender`

*Description of changes:*
Fix gitlab-tools.sh checking if `git-defender` exists

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
