### PR TITLE
sample.env - Okta and Allowed IPs further deatils

### DIFF
--- a/config/sample.env
+++ b/config/sample.env
@@ -25,15 +25,19 @@ GITLAB_RUNNER_AMI="TODO"
 # Example: mycomany.com
 R53_HOSTED_ZONE_NAME="TODO"
 
-# Comma separated list of IPv4 CICR ranges to allow requests to Backstage/GitLab load balancers
-ALLOWED_IPS=""
+# Comma separated list of IPv4 CIDR ranges to allow requests to Backstage/GitLab load balancers
+# The public IPv4 CIDR of the machine running the installation script is mandatory
+# After installation, the IP can be removed from the Security Group
+# In order to obtain your public IP, visit: https://checkip.amazonaws.com/. CIDR should be formmated as: "<MyIP>/32" eg. "1.2.3.4/32"
+ALLOWED_IPS="TODO"
 
 # Okta Identity Provider Configurations
 # See RoadieHQ documentation for details: https://www.npmjs.com/package/@roadiehq/catalog-backend-module-okta
 OKTA_API_TOKEN="TODO"
-# The org URL for your Okta domain (e.g. https://dev-12345678.okta.com/)
-OKTA_AUDIENCE="https://TODO/"
+# The org URL for your Okta domain (e.g. https://dev-12345678.okta.com)
+OKTA_AUDIENCE="https://TODO.okta.com"
 OKTA_AUTH_SERVER_ID=""
+# Application need confifured as mentioned in [Backstage Authentication documentation](https://backstage.io/docs/auth/)
 OKTA_CLIENT_ID="TODO"
 OKTA_CLIENT_SECRET="TODO"
 OKTA_IDP=""


### PR DESCRIPTION
*Description of changes:*
sample.env
Okta:
1. fix OKTA_AUDIENCE format
2. OKTA_CLIENT added link to remote doc Allowed Ips:
1. marked as mandatory
2. added guidelines how to generate personal public CIDR


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
