### PR TITLE
add CDK Bootstrap for initiating providers

### DIFF
--- a/backstage-reference/common/cicd/.gitlab-ci-aws-provider-basic.yml
+++ b/backstage-reference/common/cicd/.gitlab-ci-aws-provider-basic.yml
@@ -22,6 +22,7 @@ iac-deployment-env-provider:
     - set -a && source stack-parameters.properties && set +a
     - cd .iac/opa-basic-environment
     - yarn install
+    - cdk bootstrap
     - cdk deploy --outputs-file cdk-output.json --require-approval never
     # once CDK finished - extract output params
     - jq '.[] ' cdk-output.json | jq -r 'to_entries[]|"\(.key)=\"\(.value)\""' > cdk-output.properties

--- a/backstage-reference/common/cicd/.gitlab-ci-aws-provider-basic.yml
+++ b/backstage-reference/common/cicd/.gitlab-ci-aws-provider-basic.yml
@@ -20,9 +20,9 @@ iac-deployment-env-provider:
   script:
     # Export environment variables
     - set -a && source stack-parameters.properties && set +a
+    - cdk bootstrap aws://$AWS_ACCOUNT_ID/$AWS_DEFAULT_REGION
     - cd .iac/opa-basic-environment
     - yarn install
-    - cdk bootstrap
     - cdk deploy --outputs-file cdk-output.json --require-approval never
     # once CDK finished - extract output params
     - jq '.[] ' cdk-output.json | jq -r 'to_entries[]|"\(.key)=\"\(.value)\""' > cdk-output.properties

--- a/backstage-reference/common/cicd/.gitlab-ci-aws-provider-ecs-ec2.yml
+++ b/backstage-reference/common/cicd/.gitlab-ci-aws-provider-ecs-ec2.yml
@@ -35,6 +35,7 @@ iac-deployment-env-provider:
     - echo -e "\e[0Ksection_end:`date +%s`:yarn_install\r\e[0K"
 
     - echo -e "\e[0Ksection_start:`date +%s`:cdk_deploy[collapsed=true]\r\e[0KCDK Deploy"
+    - cdk bootstrap
     - cdk deploy --outputs-file cdk-output.json --require-approval never
     - echo -e "\e[0Ksection_end:`date +%s`:cdk_deploy\r\e[0K"
 

--- a/backstage-reference/common/cicd/.gitlab-ci-aws-provider-ecs-ec2.yml
+++ b/backstage-reference/common/cicd/.gitlab-ci-aws-provider-ecs-ec2.yml
@@ -28,6 +28,7 @@ iac-deployment-env-provider:
   script:
     # Export environment variables
     - set -a && source stack-parameters.properties && set +a
+    - cdk bootstrap aws://$AWS_ACCOUNT_ID/$AWS_DEFAULT_REGION
     - cd .iac/opa-ecs-ec2-environment
 
     - echo -e "\e[0Ksection_start:`date +%s`:yarn_install[collapsed=true]\r\e[0KYarn Install"
@@ -35,7 +36,6 @@ iac-deployment-env-provider:
     - echo -e "\e[0Ksection_end:`date +%s`:yarn_install\r\e[0K"
 
     - echo -e "\e[0Ksection_start:`date +%s`:cdk_deploy[collapsed=true]\r\e[0KCDK Deploy"
-    - cdk bootstrap
     - cdk deploy --outputs-file cdk-output.json --require-approval never
     - echo -e "\e[0Ksection_end:`date +%s`:cdk_deploy\r\e[0K"
 

--- a/backstage-reference/common/cicd/.gitlab-ci-aws-provider-ecs.yml
+++ b/backstage-reference/common/cicd/.gitlab-ci-aws-provider-ecs.yml
@@ -31,6 +31,7 @@ iac-deployment-env-provider:
   script:
     # Export environment variables
     - set -a && source stack-parameters.properties && set +a
+    - cdk bootstrap aws://$AWS_ACCOUNT_ID/$AWS_DEFAULT_REGION
     - cd .iac/opa-ecs-environment
 
     - echo -e "\e[0Ksection_start:`date +%s`:yarn_install[collapsed=true]\r\e[0KYarn Install"
@@ -38,7 +39,6 @@ iac-deployment-env-provider:
     - echo -e "\e[0Ksection_end:`date +%s`:yarn_install\r\e[0K"
 
     - echo -e "\e[0Ksection_start:`date +%s`:cdk_deploy[collapsed=true]\r\e[0KCDK Deploy"
-    - cdk bootstrap
     - cdk deploy --outputs-file cdk-output.json --require-approval never
     - echo -e "\e[0Ksection_end:`date +%s`:cdk_deploy\r\e[0K"
 

--- a/backstage-reference/common/cicd/.gitlab-ci-aws-provider-ecs.yml
+++ b/backstage-reference/common/cicd/.gitlab-ci-aws-provider-ecs.yml
@@ -38,6 +38,7 @@ iac-deployment-env-provider:
     - echo -e "\e[0Ksection_end:`date +%s`:yarn_install\r\e[0K"
 
     - echo -e "\e[0Ksection_start:`date +%s`:cdk_deploy[collapsed=true]\r\e[0KCDK Deploy"
+    - cdk bootstrap
     - cdk deploy --outputs-file cdk-output.json --require-approval never
     - echo -e "\e[0Ksection_end:`date +%s`:cdk_deploy\r\e[0K"
 

--- a/backstage-reference/common/cicd/.gitlab-ci-aws-provider-eks.yml
+++ b/backstage-reference/common/cicd/.gitlab-ci-aws-provider-eks.yml
@@ -59,6 +59,7 @@ iac-deployment-env-provider:
 
     - echo -e "\e[0Ksection_start:`date +%s`:cdk_deploy[collapsed=true]\r\e[0KCDK Deploy"
     - echo "Deploying the cluster and saving outputs in a file"
+    - cdk bootstrap
     - cdk deploy --outputs-file cdk-output.json --require-approval never
     - echo -e "\e[0Ksection_end:`date +%s`:cdk_deploy\r\e[0K"
 

--- a/backstage-reference/common/cicd/.gitlab-ci-aws-provider-eks.yml
+++ b/backstage-reference/common/cicd/.gitlab-ci-aws-provider-eks.yml
@@ -50,7 +50,7 @@ iac-deployment-env-provider:
         git add stack-parameters.properties
       fi
     - echo -e "\e[0Ksection_end:`date +%s`:existing_cluster\r\e[0K"
-
+    - cdk bootstrap aws://$AWS_ACCOUNT_ID/$AWS_DEFAULT_REGION
     - cd .iac/opa-eks-environment
 
     - echo -e "\e[0Ksection_start:`date +%s`:yarn_install[collapsed=true]\r\e[0KYarn Install"
@@ -59,7 +59,6 @@ iac-deployment-env-provider:
 
     - echo -e "\e[0Ksection_start:`date +%s`:cdk_deploy[collapsed=true]\r\e[0KCDK Deploy"
     - echo "Deploying the cluster and saving outputs in a file"
-    - cdk bootstrap
     - cdk deploy --outputs-file cdk-output.json --require-approval never
     - echo -e "\e[0Ksection_end:`date +%s`:cdk_deploy\r\e[0K"
 

--- a/backstage-reference/common/cicd/.gitlab-ci-aws-provider-serverless.yml
+++ b/backstage-reference/common/cicd/.gitlab-ci-aws-provider-serverless.yml
@@ -32,9 +32,9 @@ iac-deployment-env-provider:
   script:
     # Export environment variables
     - set -a && source stack-parameters.properties && set +a
+    - cdk bootstrap aws://$AWS_ACCOUNT_ID/$AWS_DEFAULT_REGION
     - cd .iac/opa-serverless-environment
     - yarn install
-    - cdk bootstrap
     - cdk deploy --outputs-file cdk-output.json --require-approval never
     # once CDK finished - extract output params
     - jq '.[] ' cdk-output.json | jq -r 'to_entries[]|"\(.key)=\"\(.value)\""' > cdk-output.properties

--- a/backstage-reference/common/cicd/.gitlab-ci-aws-provider-serverless.yml
+++ b/backstage-reference/common/cicd/.gitlab-ci-aws-provider-serverless.yml
@@ -34,6 +34,7 @@ iac-deployment-env-provider:
     - set -a && source stack-parameters.properties && set +a
     - cd .iac/opa-serverless-environment
     - yarn install
+    - cdk bootstrap
     - cdk deploy --outputs-file cdk-output.json --require-approval never
     # once CDK finished - extract output params
     - jq '.[] ' cdk-output.json | jq -r 'to_entries[]|"\(.key)=\"\(.value)\""' > cdk-output.properties

--- a/iac/roots/opa-platform/README.md
+++ b/iac/roots/opa-platform/README.md
@@ -27,7 +27,6 @@ Be sure to replace "\$ACCOUNT_ID" with your AWS account id and "\$AWS_PRIMARY_RE
 ```sh
 yarn install
 cdk bootstrap aws://$ACCOUNT_ID/$AWS_PRIMARY_REGION
-cdk bootstrap aws://$ACCOUNT_ID/$AWS_SECONDARY_REGION
 ```
 * ignore warnings such as 'xxx is declared but its value is never read'.
 * Make sure docker is installed and running


### PR DESCRIPTION
In order to avoid end-user to manually `cdk bootstrap` each account and region, add `cdk bootstrap` as part of creating new providers