### PR TITLE
Fix GitLab file content decoding and standardize commit response handling

### DIFF
--- a/backstage-plugins/plugins/harmonix-backend/src/api/aws-platform.ts
+++ b/backstage-plugins/plugins/harmonix-backend/src/api/aws-platform.ts
@@ -253,7 +253,9 @@ export class AppsPlatformService implements IAppsPlatformService{
       );
       throw new Error(`Failed to retrieve ${filePath} for ${repo.gitRepoName}. Response: ${result}`);
     } else {
-      return resultBody;
+      return this.git.gitProvider === GitProviders.GITLAB 
+        ? Buffer.from(resultBody, 'base64').toString('utf-8')
+        : resultBody;
     }
   }
 
@@ -476,16 +478,7 @@ export class AppsPlatformService implements IAppsPlatformService{
 
     const result = await this.git.gitProviderImpl.commitContent(change, repo, gitToken);
     console.log(result)
-    let resultBody;
-
-    if (this.git.gitProvider===GitProviders.GITLAB)
-      {
-        resultBody = await result.value.json();
-      }
-      else if (this.git.gitProvider===GitProviders.GITHUB) 
-      {
-        resultBody = result.message
-      }
+    let resultBody = result.message
     
 
     


### PR DESCRIPTION
- Decode base64 content from GitLab when retrieving files
- Remove provider-specific commit response logic, use unified message field

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

This PR fixes the following error that occurs when removing a provider from an environment. 

```
{
    "error": {
        "name": "TypeError",
        "message": "Cannot read properties of undefined (reading 'dependsOn')"
    },
    "request": {
        "method": "POST",
        "url": "/platform/update-provider"
    },
    "response": {
        "statusCode": 500
    }
}
```

### Motivation

<!-- What inspired you to submit this pull request? -->

I was not able to remove a provider from an environment. 


### For Moderators

- [X] Compile, build, tests successful before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
