### PR TITLE
feat: add retry logic for GitLab operations

### DIFF
--- a/build-script/set-gitlab-token.sh
+++ b/build-script/set-gitlab-token.sh
@@ -5,5 +5,17 @@ configDir=$scriptDir/../config
 
 source $configDir/.env
 
-GITLAB_API_TOKEN=$(aws secretsmanager get-secret-value --secret-id opa-admin-gitlab-secrets --output text --query 'SecretString' | jq -r '.apiToken')
+retry_count=0
+max_retries=30
+while [ $retry_count -lt $max_retries ]; do
+    GITLAB_API_TOKEN=$(aws secretsmanager get-secret-value --secret-id opa-admin-gitlab-secrets --output text --query 'SecretString' | jq -r '.apiToken')
+    if [[ -z "$GITLAB_API_TOKEN" || "$GITLAB_API_TOKEN" == "null" ]]; then
+        retry_count=$((retry_count + 1))
+        echo "Empty Gitlab API token, retrying... ($retry_count/$max_retries)"
+        sleep 10
+    else
+        break
+    fi
+done
+
 sed -i.bak "s/^\(SECRET_GITLAB_CONFIG_PROP_apiToken=\).*$/\1\"$GITLAB_API_TOKEN\"/g" ./config/.env && rm -f ./config/.env.bak


### PR DESCRIPTION
Add retry mechanisms for GitLab API calls and secrets retrieval to improve reliability during platform initialization

### What does this PR do?

This PR adds retry logic to GitLab operations during platform initialization to handle transient failures and improve reliability. Specifically:
- Adds retry mechanism (30 attempts, 10s interval) for GitLab project creation API calls
- Handles 401 authentication errors with automatic retry
- Detects existing projects (400 error) and proceeds without failure
- Adds retry logic for AWS Secrets Manager GitLab token retrieval

### Motivation

During platform deployment, GitLab API calls and secrets retrieval can occasionally fail due to timing issues or transient errors. This causes deployment failures that require manual intervention. Adding retry logic makes the deployment 
process more robust and reduces manual troubleshooting.

### For Moderators

- [X] Compile, build, tests successful before merge?

### Additional Notes

- Retry count set to 30 with 10-second intervals (5 minutes total)
- Changes are isolated to build scripts: `gitlab-tools.sh` and `set-gitlab-token.sh`
- No changes to core application logic or infrastructure code